### PR TITLE
Archive this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-# [sfosc.org/preview](https://sfosc.org/preview/)
+## Archived
+
+The preview workaround is no longer necessary,
+we're building from https://github.com/sfosc/sfosc instead.
+
+See https://github.com/sfosc/sfosc/issues/93 for more context.
+
+# sfosc.org/preview
 
 [![Build Status](https://drone.sfosc.robin-it.com/api/badges/Beanow/sfosc-drone-cron/status.svg)](https://drone.sfosc.robin-it.com/Beanow/sfosc-drone-cron)
 
 Currently being built from a workaround at: https://github.com/Beanow/sfosc-drone-cron
-
-


### PR DESCRIPTION
I propose we archive this repository, as suggested in https://github.com/sfosc/sfosc/issues/93
The main site is updated automatically from master now, so we no longer need the preview.